### PR TITLE
Doing more cleanup when killing everything

### DIFF
--- a/kill-all.sh
+++ b/kill-all.sh
@@ -3,21 +3,25 @@
 source ./env.sh
 
 for i in `cat hosts|grep -v \\\\[`;
-do 
+do
 
     echo "########################################################################"
+    echo "Removing: ${i}"
 
     baseimage="$VMS/$i-base.qcow2"
     image="$VMS/$i.qcow2"
     xmlfile="$VMS/$i.xml"
     dockerdisk="$VMS/$i-docker.qcow2"
+    glusterdisk="$VMS/$i-glusterfs.qcow2"
 
     virsh destroy $i
     virsh undefine $i
-    rm $baseimage $image $dockerdisk $xmlfile
+    rm $baseimage $image $dockerdisk $xmlfile $glusterdisk
+    ssh-keygen -R $i
 
 done
 
 virsh list --all
 
 exit
+


### PR DESCRIPTION
Specifically, also removing the glusterfs disks that get created, and the leftover ssh known hosts info, so we don't have to manually run 'ssh-keygen -R blah'