### PR TITLE
Resizing memory for logging and metrics components

### DIFF
--- a/group_vars/OSEv3/logging.yml
+++ b/group_vars/OSEv3/logging.yml
@@ -1,3 +1,8 @@
 # Install logging
 openshift_logging_install_logging: true
 openshift_logging_es_nodeselector: {"node-role.kubernetes.io/infra":"true"}
+
+# Tuning for small home labs
+openshift_logging_es_cpu_limit: 500m
+openshift_logging_es_memory_limit: 1G
+openshift_logging_fluentd_memory_limit: 500M

--- a/group_vars/OSEv3/metrics.yml
+++ b/group_vars/OSEv3/metrics.yml
@@ -1,3 +1,14 @@
 # Install metrics
 openshift_metrics_install_metrics: true
+openshift_metrics_cassandra_nodeselector: {"node-role.kubernetes.io/infra":"true"}
+openshift_metrics_hawkular_nodeselector: {"node-role.kubernetes.io/infra":"true"}
+openshift_metrics_heapster_nodeselector: {"node-role.kubernetes.io/infra":"true"}
 openshift_metrics_hawkular_hostname: 'hawkular-metrics.{{ openshift_master_default_subdomain }}'
+
+# Tuning for small home labs
+openshift_metrics_cassandra_limits_memory: 2G
+openshift_metrics_cassandra_requests_memory: 500m
+openshift_metrics_hawkular_limits_memory: 2G
+openshift_metrics_hawkular_requests_memory: 500m
+openshift_metrics_heapster_limits_memory: 2G
+openshift_metrics_heapster_requests_memory: 500m


### PR DESCRIPTION
Resizing memory for logging and metrics components to support a small home lab where there is otherwise insufficient memory.  This allows the components to start up within the Kubernetes memory limits for the node.